### PR TITLE
Linux appimage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ typings/
 .dynamodb/
 
 # End of https://www.gitignore.io/api/node
+
+*.lock
+/client0.1_electron/dist/

--- a/client0.1_electron/package-lock.json
+++ b/client0.1_electron/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "LanPartyTool",
+  "name": "LanTool",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/client0.1_electron/package.json
+++ b/client0.1_electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "LanTool",
   "version": "1.0.0",
-  "description": "LanTool Kann Große Datein Spliten und im Netzwerk verteilen",
+  "description": "LanTool is a tool for sharing files within a local network such as torrent. It splits files and make them available for all other clients within the network.",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/client0.1_electron/package.json
+++ b/client0.1_electron/package.json
@@ -7,7 +7,22 @@
     "start": "electron .",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
     "package-win": "electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --icon=assets/icons/win/icon.ico --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"Shopping List\"",
-    "package-linux": "electron-packager . --overwrite --platform=linux --arch=x64 --icon=assets/icons/png/icon.png --prune=true --out=release-builds"
+    "package-linux": "electron-packager . --overwrite --platform=linux --arch=x64 --icon=assets/icons/png/icon.png --prune=true --out=release-builds",
+    "dist": "electron-builder"
+  },
+  "build": {
+    "appId": "lantool.sterei",
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ]
+    }
   },
   "author": "Steffen Reimann",
   "license": "MIT",
@@ -22,6 +37,7 @@
   },
   "devDependencies": {
     "electron": "^1.8.7",
+    "electron-builder": "^20.38.5",
     "electron-packager": "^12.1.1"
   }
 }


### PR DESCRIPTION
# Changes
Added electron-builder as dependencies in package.json.
Configuration for linux AppImage build.

# Creating Linux AppImage
Building AppImage is only working on linux machines.
Run the command:
```
npm run dist
```